### PR TITLE
Correction of a copy/Paste bug

### DIFF
--- a/Meziantou.WpfFontAwesome/FontAwesomeIcon.cs
+++ b/Meziantou.WpfFontAwesome/FontAwesomeIcon.cs
@@ -68,9 +68,9 @@ namespace Meziantou.WpfFontAwesome
             }
             else if (obj.DuotoneIcon.HasValue)
             {
-                var enumValue = obj.LightIcon.Value;
+                var enumValue = obj.DuotoneIcon.Value;
                 obj.SetValue(IconCharacterProperty, new string((char)enumValue, 1));
-                obj.SetValue(FinalFontFamilyProperty, GetFontFamily(enumValue, ProLightFontFamily, freeFontFamily: null));
+                obj.SetValue(FinalFontFamilyProperty, GetFontFamily(enumValue, ProDuotoneFontFamily, freeFontFamily: null));
             }
             else
             {


### PR DESCRIPTION
in 

`else if (obj.DuotoneIcon.HasValue)
{
    var enumValue = obj.DuotoneIcon.Value;
    obj.SetValue(IconCharacterProperty, new string((char)enumValue, 1));
    obj.SetValue(FinalFontFamilyProperty, GetFontFamily(enumValue, ProDuotoneFontFamily,     freeFontFamily: null));
}`

`ob.DuotoneIcon.Value` was `obj.LightIcon.Value` and the font family was set to ProLightFontFamily

